### PR TITLE
Error handling for inputs

### DIFF
--- a/multiselect.go
+++ b/multiselect.go
@@ -273,7 +273,10 @@ func (m *MultiSelect) Prompt(config *PromptConfig) (interface{}, error) {
 
 	// start waiting for input
 	for {
-		r, _, _ := rr.ReadRune()
+		r, _, err := rr.ReadRune()
+		if err != nil {
+			return "", err
+		}
 		if r == '\r' || r == '\n' {
 			break
 		}


### PR DESCRIPTION
SIGHUP is ignored and the program gets into a weird loop waiting for select to happen.
Steps to reproduce:
`go run examples/longmulti.go`
In a different terminat run `kill -s hup (pidof longmulti)` Or simply close the terminal while the program waits for input.
The program is not killed and gets in a weird state slowly killing your CPU